### PR TITLE
Fix unused-return error

### DIFF
--- a/ACROBOTIC_SSD1306.cpp
+++ b/ACROBOTIC_SSD1306.cpp
@@ -136,6 +136,7 @@ bool ACROBOTIC_SSD1306::putChar(unsigned char ch)
        // Font array starts at 0, ASCII starts at 32
        sendData(pgm_read_byte(&m_font[(ch-32)*m_font_width+m_font_offset+i])); 
     }
+    return 1;
 }
 
 void ACROBOTIC_SSD1306::putString(const char *string)


### PR DESCRIPTION
I got an error in my Arduino setup, which has -Wall turned on. It complained that there was no return value emitted from all branches of `putChar`, so I added this line which made the error/warning go away.